### PR TITLE
Implement OpenKH Hints

### DIFF
--- a/KhTracker.sln
+++ b/KhTracker.sln
@@ -1,20 +1,26 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27703.2042
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.31112.23
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "KhTracker", "KhTracker\KhTracker.csproj", "{91260922-9FBA-4508-9593-430514E34A2B}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
 		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{91260922-9FBA-4508-9593-430514E34A2B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{91260922-9FBA-4508-9593-430514E34A2B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{91260922-9FBA-4508-9593-430514E34A2B}.Debug|x64.ActiveCfg = Debug|x64
+		{91260922-9FBA-4508-9593-430514E34A2B}.Debug|x64.Build.0 = Debug|x64
 		{91260922-9FBA-4508-9593-430514E34A2B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{91260922-9FBA-4508-9593-430514E34A2B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{91260922-9FBA-4508-9593-430514E34A2B}.Release|x64.ActiveCfg = Release|x64
+		{91260922-9FBA-4508-9593-430514E34A2B}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/KhTracker/App.config
+++ b/KhTracker/App.config
@@ -1,7 +1,7 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <configSections>
-        <sectionGroup name="userSettings" type="System.Configuration.UserSettingsGroup, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" >
+        <sectionGroup name="userSettings" type="System.Configuration.UserSettingsGroup, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
             <section name="KhTracker.Properties.Settings" type="System.Configuration.ClientSettingsSection, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" allowExeDefinition="MachineToLocalUser" requirePermission="false" />
         </sectionGroup>
     </configSections>
@@ -84,4 +84,12 @@
             </setting>
         </KhTracker.Properties.Settings>
     </userSettings>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.ValueTuple" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
 </configuration>

--- a/KhTracker/KhTracker.csproj
+++ b/KhTracker/KhTracker.csproj
@@ -54,6 +54,11 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Data" />
+    <Reference Include="System.IO.Compression" />
+    <Reference Include="System.IO.Compression.FileSystem" />
+    <Reference Include="System.Memory, Version=4.0.1.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL" />
+    <Reference Include="System.Text.Json, Version=4.0.1.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL" />
+    <Reference Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL" />
     <Reference Include="System.Xml" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Core" />

--- a/KhTracker/KhTracker.csproj
+++ b/KhTracker/KhTracker.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\ILMerge.3.0.41\build\ILMerge.props" Condition="Exists('..\packages\ILMerge.3.0.41\build\ILMerge.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -28,6 +29,8 @@
     <IsWebBootstrapper>false</IsWebBootstrapper>
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -57,7 +60,10 @@
     <Reference Include="System.IO.Compression" />
     <Reference Include="System.IO.Compression.FileSystem" />
     <Reference Include="System.Memory, Version=4.0.1.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL" />
-    <Reference Include="System.Text.Json, Version=4.0.1.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL" />
+    <Reference Include="System.Text.Json, Version=4.0.1.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <EmbedInteropTypes>False</EmbedInteropTypes>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL" />
     <Reference Include="System.Xml" />
     <Reference Include="Microsoft.CSharp" />
@@ -153,6 +159,7 @@
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
     <Resource Include="Fonts\HVD_Comic_Serif_Pro.otf" />
+    <None Include="packages.config" />
     <None Include="Properties\Settings.settings">
       <Generator>SettingsSingleFileGenerator</Generator>
       <LastGenOutput>Settings.Designer.cs</LastGenOutput>
@@ -614,4 +621,27 @@
     <Resource Include="Images\NumbersBlue\_QuestionMark.png" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\ILMerge.3.0.41\build\ILMerge.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\ILMerge.3.0.41\build\ILMerge.props'))" />
+  </Target>
+  <ItemGroup>
+    <PackageReference Include="ILMerge" Version="3.0.41" />
+  </ItemGroup>
+
+  <Target Name="ILMerge">
+    <!-- the ILMergePath property points to the location of ILMerge.exe console application -->
+    <Exec Command="$(ILMergeConsolePath) bin\Release\KhTracker.exe ^
+    /out:KhTracker.exe ^
+    bin\Release\System.Text.Json.dll ^
+    bin\Release\System.Buffers.dll ^
+    bin\Release\System.Memory.dll ^
+    bin\Release\System.Numerics.Vectors.dll ^
+    bin\Release\System.Runtime.CompilerServices.Unsafe.dll ^
+    bin\Release\System.Text.Encodings.Web.dll ^
+    bin\Release\System.Threading.Tasks.Extensions.dll ^
+    bin\Release\System.ValueTuple.dll" />
+  </Target>
 </Project>

--- a/KhTracker/MainWindow.xaml
+++ b/KhTracker/MainWindow.xaml
@@ -36,6 +36,7 @@
                 <MenuItem Header="Mode">
                     <MenuItem Header="Load JSmartee Hints" Click="LoadHints"/>
                     <MenuItem Header="Load Shananas Hintless Seed" Click="ParseSeed"/>
+                    <MenuItem Header="Load OpenKH Seed" Click="OpenKHSeed"/>
                 </MenuItem>
                 <Separator/>
                 <MenuItem Header="Broadcast Window" HorizontalAlignment="Left" Click="BroadcastWindow_Open" Width="235"/>

--- a/KhTracker/MainWindow.xaml
+++ b/KhTracker/MainWindow.xaml
@@ -67,7 +67,7 @@
                 <MenuItem Name="TopMostOption" Header="Always on Top" IsCheckable="True" IsChecked="False" Click="TopMostToggle"/>
             </MenuItem>
             <MenuItem Name="ModeDisplay" Header="Hints Mode" Focusable="False" IsHitTestVisible="False"/>
-            <MenuItem Header="v2.5.2" IsHitTestVisible="False" Focusable="False" HorizontalAlignment="Right"/>
+            <MenuItem Header="v2.6.0" IsHitTestVisible="False" Focusable="False" HorizontalAlignment="Right"/>
         </Menu>
 
         <Grid>

--- a/KhTracker/Options.cs
+++ b/KhTracker/Options.cs
@@ -404,6 +404,8 @@ namespace KhTracker
                     LoadHints(files[0]);
                 else if (Path.GetExtension(files[0]).ToUpper() == ".PNACH")
                     ParseSeed(files[0]);
+                else if (Path.GetExtension(files[0]).ToUpper() == ".ZIP")
+                    OpenKHSeed(files[0]);
             }
         }
 
@@ -867,6 +869,8 @@ namespace KhTracker
             {"Lamp Charm (Genie)", "Lamp" },
             {"Feather Charm (Peter Pan)", "Feather" },
             {"Torn Pages", "TornPage" },
+            {"Second Chance", "SecondChance" },
+            {"Once More", "OnceMore" }
 
         };
 
@@ -897,6 +901,10 @@ namespace KhTracker
 
                                     foreach (var world in worlds)
                                     {
+                                        if (world.Key == "Critical Bonuses" || world.Key == "Garden of Assemblage")
+                                        {
+                                            continue;
+                                        }
                                         foreach (var item in world.Value)
                                         {
                                             data.WorldCheckCount[convertOpenKH[world.Key]].Add(convertOpenKH[item]);
@@ -911,6 +919,28 @@ namespace KhTracker
                                         data.Grids[key].WorldComplete();
                                         SetReportValue(data.Hints[key], 1);
                                     }
+
+                                    break;
+
+                                case "JSmartee":
+                                    SetMode(Mode.Hints);
+                                    var reports = JsonSerializer.Deserialize<Dictionary<string, Dictionary<string,object>>>(hintObject["Reports"].ToString());
+
+                                    List<int> reportKeys = reports.Keys.Select(int.Parse).ToList();
+                                    reportKeys.Sort();
+
+                                    foreach (var report in reportKeys)
+                                    {
+                                        var world = convertOpenKH[reports[report.ToString()]["World"].ToString()];
+                                        var count = reports[report.ToString()]["Count"].ToString();
+                                        var location = convertOpenKH[reports[report.ToString()]["Location"].ToString()];
+                                        data.reportInformation.Add(new Tuple<string, int>(world, int.Parse(count)));
+                                        data.reportLocations.Add(location);
+                                        
+                                    }
+                                    ReportsToggle(true);
+                                    data.hintsLoaded = true;
+                                    HintText.Content = "Hints Loaded";
 
                                     break;
 


### PR DESCRIPTION
Adds the ability to parse hints generated by the OpenKH Seed Generator.

This adds dependencies that are merged into the binary using ILMerge.

In Visual Studio, go to Project > Manage Nuget Packages

Install ILMerge

Open a command prompt and navigate to the folder with `KhTracker.csproj`

Execute command `msbuild /t:ILMerge` 

This builds the solution using the using the "Release" target.

Line 637 of `KhTracker.csproj` can be edited to place the build output wherever is most convenient for you. Currently it just dumps to the same folder as `KhTracker.csproj`. Just make sure the directory exists before running `msbuild /t:ILMerge`.

Any further dependencies can be added after line 645 as they are needed.